### PR TITLE
OSV-8287|OSV-8291|OSV-8347|OSV-8337|OSV-8338 : Exclude jackson-mapper-asl ,nimbus-jose-jwt, json-smart, guava, gson from hadoop2 due to CVE

### DIFF
--- a/kafka/hbase-kafka-proxy/pom.xml
+++ b/kafka/hbase-kafka-proxy/pom.xml
@@ -103,6 +103,26 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+          <exclusion>
+              <groupId>com.google.code.gson</groupId>
+              <artifactId>gson</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>net.minidev</groupId>
+              <artifactId>json-smart</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-mapper-asl</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>com.nimbusds</groupId>
+              <artifactId>nimbus-jose-jwt</artifactId>
+          </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
…-asl ,nimbus-jose-jwt, json-smart, guava, gson from hadoop2 due to CVE