### PR TITLE
OSV-21095 - CVE - Increasing hbase-shaded-netty to 4.1.13 (netty 4.1.131.Final) to fix CVE-2025-58057

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.hbase.thirdparty</groupId>
+        <artifactId>hbase-shaded-netty</artifactId>
+        <version>4.1.13</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>


### PR DESCRIPTION
- Library : org.apache.hbase.thirdparty_hbase-shaded-netty
- Version : -> 4.1.13
- Tickets : OSV-21095, OSV-21092, OSV-21087, OSV-21079, OSV-21076, OSV-21073